### PR TITLE
corrected translation

### DIFF
--- a/src/constants/translations/it-IT.ts
+++ b/src/constants/translations/it-IT.ts
@@ -4,8 +4,8 @@ import en_US from './en-US';
 const it_IT: Translation = {
   ...en_US,
   // DASHBOARD
-  CREDIT: 'Guadagni',
-  DEBIT: 'Spese',
+  CREDIT: 'Spese',
+  DEBIT: 'Guadagni',
   RECENT_TRANSACTIONS: 'Transazioni Recenti',
   MY_ACCOUNTS: 'I Miei Conti',
 


### PR DESCRIPTION
Debit and credit are inverted in the italian translation. "Spese" is shown in green and "Guadagni" is shown in red and this is not ideal. Even worse, "Guadagni" (which means to gain) corresponds to when money is spent and, viceversa, "Spese" (which means to spend) corresponds to when you gain money.